### PR TITLE
bumping go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/techdufus/fluxctl
 
-go 1.18
+go 1.22
 
 require github.com/spf13/cobra v1.8.0
 


### PR DESCRIPTION
This pull request includes a minor but important change to the `go.mod` file. The Go language version has been updated from 1.18 to 1.22. This change could have implications on the compatibility and performance of the code, so it's crucial to ensure all parts of the application work as expected with this new Go version.